### PR TITLE
add regex support for --text parameter

### DIFF
--- a/memento_cli/memento.py
+++ b/memento_cli/memento.py
@@ -98,7 +98,7 @@ def bisect(start, end, memento_urls, text, missing, browser) -> str:
     # look in the page text
     else:
         print("\r" + meter(start, end, len(memento_urls)), end="")
-        text_in_page = text in page_text
+        text_in_page = bool(re.search(text, page_text))
 
     # do we want to find the page where the text went missing?
     if missing:


### PR DESCRIPTION
In order to search for text in German, regex is needed to catch conjugations and declensions. 

Example: `memento bisect --text "queer"` get's only exact matches and not `Queeres`, `queere` and so on.

see: https://katharinabrunner.de/2023/09/how-to-find-differences-on-websites-in-the-internet-archive-automatically/ 

I added a basic regex support. 