### PR TITLE
Fix: Strip whitespace and newlines from datetime strings

### DIFF
--- a/memento_cli/memento.py
+++ b/memento_cli/memento.py
@@ -35,11 +35,12 @@ def get_mementos(timemap_url) -> list[Memento]:
     if resp.headers.get("content-type") == "application/link-format":
         for link in parse_links(resp.text):
             if link.get("rel") == "memento":
+                datetime_str = link["datetime"].strip(' "\n\r')
                 mementos.append(
                     Memento(
                         link["url"],
                         datetime.datetime.strptime(
-                            link["datetime"], "%a, %d %b %Y %H:%M:%S GMT"
+                            datetime_str, "%a, %d %b %Y %H:%M:%S GMT"
                         ),
                     )
                 )


### PR DESCRIPTION
I got a timestamp parsing error and fixed it in the PR

```bash
memento list https://web.archive.org/web/20230407140923/https:/help.twitter.com/en/rules-and-policies/hateful-conduct-policy

Traceback (most recent call last):
  File "/opt/homebrew/bin/memento", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/memento_cli/__init__.py", line 38, in main
    cli()
  File "/Users/user/Library/Python/3.11/lib/python/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/Library/Python/3.11/lib/python/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/user/Library/Python/3.11/lib/python/site-packages/click/core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/Library/Python/3.11/lib/python/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/Library/Python/3.11/lib/python/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/memento_cli/__init__.py", line 21, in list
    for mem in memento.get_mementos(timemap_url):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/memento_cli/memento.py", line 41, in get_mementos
    datetime.datetime.strptime(
  File "/opt/homebrew/Cellar/python@3.11/3.11.14_2/Frameworks/Python.framework/Versions/3.11/lib/python3.11/_strptime.py", line 567, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.14_2/Frameworks/Python.framework/Versions/3.11/lib/python3.11/_strptime.py", line 352, in _strptime
    raise ValueError("unconverted data remains: %s" %
ValueError: unconverted data remains: "
```


After the fix the commands work again. This example shows the whitespaces/trailing trash at the end of the URL (████):

```bash
memento bisect --text "Geschlechtseintrag" https://web.archive.org/web/20241211111436/https://www.auswaertiges-amt.de/de/service/laender/usa-node/usavereinigtestaatensicherheit-201382

Found your archive snapshot: https://web.archive.org/web/20250311184444/https://www.auswaertiges-amt.de/de/service/laender/usa-node/usavereinigtestaatensicherheit-201382████
```
